### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jekyll-docker.yml
+++ b/.github/workflows/jekyll-docker.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/neuralegion.yml
+++ b/.github/workflows/neuralegion.yml
@@ -149,6 +149,9 @@
 
 name: "NeuraLegion"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -5,6 +5,9 @@
 
 # pulled from repo
 name: "Rubocop"
+permissions:
+  contents: read
+  security-events: write
 
 on:
   push:

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -5,6 +5,8 @@
 # This workflow will install a prebuilt Ruby version, install dependencies, and
 # run tests and linters.
 name: "Ruby on Rails CI"
+permissions:
+  contents: read
 on:
   push:
     branches: [ "master" ]

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -5,6 +5,8 @@
 # For more information, see:
 # https://github.com/github/super-linter
 name: Lint Code Base
+permissions:
+  contents: read
 
 on:
   push:

--- a/Data/Scripts/020_Debug/002_Animation editor/004_AnimEditor_ExportImport.rb
+++ b/Data/Scripts/020_Debug/002_Animation editor/004_AnimEditor_ExportImport.rb
@@ -57,7 +57,7 @@ module BattleAnimationEditor
       cmdwin.update
       if Input.trigger?(Input::USE) && animfiles.length > 0
         begin
-          textdata = loadBase64Anim(IO.read(animfiles[cmdwin.index]))
+          textdata = loadBase64Anim(File.read(animfiles[cmdwin.index]))
           throw "Bad data" if !textdata.is_a?(PBAnimation)
           textdata.id = -1 # this is not an RPG Maker XP animation
           pbConvertAnimToNewFormat(textdata)

--- a/Data/Scripts/020_Debug/003_Debug menus/003_Debug_MenuExtraCode.rb
+++ b/Data/Scripts/020_Debug/003_Debug menus/003_Debug_MenuExtraCode.rb
@@ -631,7 +631,7 @@ def pbImportAllAnimations
         pbSafeCopyFile(image, RTP.getImagePath("Graphics/Animations/" + File.basename(image)), "Graphics/Animations/" + File.basename(image))
       end
       Dir.glob(folder + "/*.anm") do |f|
-        textdata = BattleAnimationEditor.loadBase64Anim(IO.read(f)) rescue nil
+        textdata = BattleAnimationEditor.loadBase64Anim(File.read(f)) rescue nil
         if textdata.is_a?(PBAnimation)
           index = pbAllocateAnimation(animations, textdata.name)
           missingFiles = []

--- a/Data/Scripts/021_Compiler/001_Compiler.rb
+++ b/Data/Scripts/021_Compiler/001_Compiler.rb
@@ -79,7 +79,7 @@ module Compiler
   def csvQuote(str, always = false)
     return "" if nil_or_empty?(str)
     if always || str[/[,\"]/]   # || str[/^\s/] || str[/\s$/] || str[/^#/]
-      str = str.gsub(/\"/, "\\\"")
+      str = str.gsub(/\\/, "\\\\\\").gsub(/\"/, "\\\"")
       str = "\"#{str}\""
     end
     return str


### PR DESCRIPTION
Potential fix for [https://github.com/AdamOswald/pokemon-essentials/security/code-scanning/5](https://github.com/AdamOswald/pokemon-essentials/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimum permissions required for the workflow to function correctly. Since the workflow is a linting workflow that primarily reads the repository contents, we will set `contents: read` as the permission. This ensures that the workflow has only the permissions it needs and no more.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Add permissions block to GitHub workflow files to address code scanning security alert and fix some Ruby file reading methods

Bug Fixes:
- Replaced `IO.read()` with `File.read()` in several Ruby scripts to improve file reading consistency

Enhancements:
- Updated CSV quoting method to properly escape backslashes in string handling

CI:
- Added `permissions: contents: read` to multiple GitHub workflow files to restrict workflow permissions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow permissions for several GitHub Actions to explicitly set repository access levels.
- **Refactor**
	- Standardized file reading methods for animation import features to use a consistent approach.
	- Improved string escaping for CSV output to better handle backslashes and quotes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->