### PR TITLE
Potential fix for code scanning alert no. 13: Missing regular expression anchor

### DIFF
--- a/Data/Scripts/021_Compiler/001_Compiler.rb
+++ b/Data/Scripts/021_Compiler/001_Compiler.rb
@@ -602,7 +602,7 @@ module Compiler
           field = csvfield!(rec)
           if nil_or_empty?(field)
             subrecord.push(nil)
-          elsif field[/^1|[Tt][Rr][Uu][Ee]|[Yy][Ee][Ss]|[Tt]|[Yy]$/]
+          elsif field[/\A(1|[Tt][Rr][Uu][Ee]|[Yy][Ee][Ss]|[Tt]|[Yy])\z/]
             subrecord.push(true)
           else
             subrecord.push(false)


### PR DESCRIPTION
Potential fix for [https://github.com/AdamOswald/pokemon-essentials/security/code-scanning/13](https://github.com/AdamOswald/pokemon-essentials/security/code-scanning/13)

To fix the issue, we need to ensure that all alternatives in the regular expression are consistently anchored to match the entire string. This can be achieved by wrapping the entire pattern in parentheses and applying the `\A` (start of string) and `\z` (end of string) anchors to the entire expression. This ensures that the regular expression matches only if the entire input string conforms to one of the specified patterns.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Added start and end string anchors to prevent partial matches in boolean parsing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of true boolean values in CSV parsing to prevent partial matches, ensuring only exact matches are recognized as true.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->